### PR TITLE
Set alternate alphabet to exclude lowercase by default

### DIFF
--- a/src/plm.c
+++ b/src/plm.c
@@ -373,7 +373,6 @@ alignment_t *MSARead(char *alignFile, options_t *options) {
     for (int i = 0; i < ali->nSites; i++) siteValid[i] = 1;
     if (ali->target >= 0) {
         for (int i = 0; i < ali->nSites; i++) {
-
             /* Discard gaps */
             if (seq(ali->target, i) <= 0) siteValid[i] = 0;
         }
@@ -522,7 +521,7 @@ letter_t MSAReadCode(char c, char *alphabet, int nCodes) {
     letter_t i = 0;
 
     /* Protein-specific treatment of '.' */
-    if (c == '.') c = '-'; // Assumes . are gpas in alphabet
+    if (c == '.') c = '-'; // Assumes '.' are gaps in alphabet
 
     /* Store lowercase characters as down-shifted by nCodes */
     while ((i < nCodes - 1) && toupper(c) != alphabet[i]) i++;

--- a/src/plm.c
+++ b/src/plm.c
@@ -373,14 +373,9 @@ alignment_t *MSARead(char *alignFile, options_t *options) {
     for (int i = 0; i < ali->nSites; i++) siteValid[i] = 1;
     if (ali->target >= 0) {
         for (int i = 0; i < ali->nSites; i++) {
-            /* For proteins, remove lower case and gap columns */
-            if ((ali->alphabet == codesAA) 
-                && (seq(ali->target, i) < 0))
-                siteValid[i] = 0;
+
             /* Discard gaps */
-            if ((ali->alphabet == codesAA)
-                || (options->estimatorMAP == INFER_MAP_PLM_GAPREDUCE))
-                if (seq(ali->target, i) == 0) siteValid[i] = 0;
+            if (seq(ali->target, i) <= 0) siteValid[i] = 0;
         }
         nValidSites = 0;
         for (int i = 0; i < ali->nSites; i++)
@@ -527,7 +522,7 @@ letter_t MSAReadCode(char c, char *alphabet, int nCodes) {
     letter_t i = 0;
 
     /* Protein-specific treatment of '.' */
-    if (alphabet == codesAA) if (c == '.') c = '-';
+    if (c == '.') c = '-'; // Assumes . are gpas in alphabet
 
     /* Store lowercase characters as down-shifted by nCodes */
     while ((i < nCodes - 1) && toupper(c) != alphabet[i]) i++;


### PR DESCRIPTION
This change just removes the hard coding of alphabet to be codesAA for removing lowerCase and '.' gaps.